### PR TITLE
fix(docs): desktop sidebar nav + full-card click targets

### DIFF
--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -254,9 +254,12 @@ const jsonLd = {
       transform: none;
     }
   }
+  /* NB: do NOT position this — the whole-card stretched link (.hub-card-go::after)
+     anchors to the nearest positioned ancestor. If the head is positioned, the
+     clickable overlay shrinks to just the header row, so clicks on the blurb or
+     the gaps between elements do nothing. Keeping it static lets the overlay
+     cover the entire card. */
   .hub-card-head {
-    position: relative;
-    z-index: 2;
     display: flex;
     align-items: center;
     gap: var(--sp-3);

--- a/src/styles/docs.css
+++ b/src/styles/docs.css
@@ -19,6 +19,14 @@
 .docs-groups > nav.group {
   display: block;
 }
+/* Modern engines (Chrome 131+, Safari 18.4+, Firefox 139+) wrap a closed
+   <details>'s content in a ::details-content pseudo with content-visibility:hidden,
+   which `display: block` on the children cannot override. Force it visible so the
+   desktop sidebar is an always-open list regardless of the [open] state. The
+   `display` rule above still covers older engines that hide via display:none. */
+.docs-groups::details-content {
+  content-visibility: visible;
+}
 .docs-side {
   position: sticky;
   top: calc(var(--header-h) + var(--sp-4));
@@ -366,6 +374,12 @@
   }
   .docs-groups:not([open]) > nav.group {
     display: none;
+  }
+  /* Restore the disclosure on phones: undo the desktop force-visible so a closed
+     drawer actually hides its content (modern engines), matching the display
+     rule above (older engines). */
+  .docs-groups:not([open])::details-content {
+    content-visibility: hidden;
   }
   .docs-groups[open] > nav.group:first-of-type {
     margin-top: var(--sp-4);


### PR DESCRIPTION
Two bugs reported on the deployed docs.

## 1. Left nav missing on desktop
The sidebar nav groups are in a closed `<details class="docs-groups">` forced open on desktop via `display: block` on the children. But modern engines (Chrome 131+, Safari 18.4+, Firefox 139+) hide a closed `<details>`'s content through a `::details-content` pseudo with `content-visibility: hidden` — which `display` can't override. So on an up-to-date browser the desktop sidebar collapsed to just the search box (markup was present, CSS-hidden).

**Fix:** `.docs-groups::details-content { content-visibility: visible }` on desktop; restore `content-visibility: hidden` for the closed drawer at ≤760px. Legacy `display` rules still cover older engines.

## 2. Docs hub cards only clickable on the header
`.hub-card-head` was `position: relative`, making it the containing block for the whole-card stretched link (`.hub-card-go::after`). The clickable overlay shrank to the header row, so clicks on the blurb or the gaps between elements did nothing.

**Fix:** keep `.hub-card-head` static so the overlay anchors to `.hub-card` and covers the whole card.

## Verified in-browser (preview)
- Desktop (1280): all 7 nav groups + 28 links visible, `::details-content` computed `visible`, 0 horizontal overflow
- Mobile (390): nav collapsed by default (groups height 0), expands on toggle, 0 overflow
- `/docs` cards: blurb, gaps, title, and padding all resolve to the card link; per-page sub-links still resolve individually
- `bun run build` clean