### PR TITLE
fix(a11y): WCAG AA contrast + heading order across all pages

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -35,7 +35,7 @@ const cols = [
     {
       cols.map((c) => (
         <nav class="col" aria-label={c.title}>
-          <h4>{c.title}</h4>
+          <p class="col-t">{c.title}</p>
           {c.links.map((l) => (
             <a href={l.href} {...("ext" in l && l.ext ? { target: "_blank", rel: "noopener" } : {})}>
               {l.label}
@@ -89,20 +89,20 @@ const cols = [
   }
   .latin {
     font-style: italic;
-    color: var(--accent-dim);
+    color: var(--accent-text);
   }
   .col {
     display: flex;
     flex-direction: column;
     gap: var(--sp-2);
   }
-  .col h4 {
+  .col .col-t {
     font-family: var(--font-mono);
     font-size: var(--fs-3xs);
     text-transform: uppercase;
     letter-spacing: var(--tracking-eyebrow);
     color: var(--text-faint);
-    margin-bottom: var(--sp-2);
+    margin: 0 0 var(--sp-2);
   }
   .col a {
     color: var(--text-muted);

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -163,7 +163,7 @@ const links = [
     transform: scaleX(1);
   }
   .nav-link.active {
-    color: var(--accent-bright);
+    color: var(--accent-text);
   }
   .actions {
     display: flex;

--- a/src/dashboard/components/ControlRail.tsx
+++ b/src/dashboard/components/ControlRail.tsx
@@ -34,7 +34,7 @@ export function ControlRail() {
   return (
     <aside class="rail scroll-thin">
       <div>
-        <h3>Scenario</h3>
+        <h2>Scenario</h2>
         {orderedCats.map((cat) => {
           const items = groups.get(cat)!;
           const open = items.includes(scenario.value);
@@ -58,7 +58,7 @@ export function ControlRail() {
       </div>
 
       <div>
-        <h3>Adapters ({sel.size})</h3>
+        <h2>Adapters ({sel.size})</h2>
         <div class="rail-actions">
           <button class="mini-btn" onClick={() => setAdapters(present)}>All</button>
           <button class="mini-btn" onClick={() => setAdapters(celerisIds())}>Celeris</button>

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -47,7 +47,7 @@
   font-size: var(--fs-2xs);
 }
 .dbar .meta-link:hover {
-  color: var(--accent-bright);
+  color: var(--accent-text);
 }
 .dbar-label {
   font-family: var(--font-mono);
@@ -117,7 +117,7 @@
   line-height: 1;
 }
 .hstat.key .hn {
-  color: var(--accent-bright);
+  color: var(--accent-text);
 }
 .hstat .hl {
   font-family: var(--font-mono);
@@ -148,13 +148,14 @@
   flex-direction: column;
   gap: var(--sp-5);
 }
-.rail h3 {
+.rail h2 {
   font-family: var(--font-mono);
   font-size: var(--fs-3xs);
+  font-weight: var(--fw-medium);
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);
   color: var(--text-faint);
-  margin-bottom: var(--sp-2);
+  margin: 0 0 var(--sp-2);
 }
 
 .dash-main {
@@ -204,7 +205,7 @@
   background: var(--surface-2);
 }
 .tab.active {
-  color: var(--accent-bright);
+  color: var(--accent-text);
   background: var(--surface-2);
   border-color: var(--border);
   box-shadow: inset 0 -2px 0 var(--accent);
@@ -347,11 +348,11 @@
   font-weight: var(--fw-medium);
 }
 .bar-row.win .bar-val {
-  color: var(--accent-bright);
+  color: var(--accent-text);
   font-weight: var(--fw-bold);
 }
 .bar-row.celeris .bar-label {
-  color: var(--accent-bright);
+  color: var(--accent-text);
   font-weight: var(--fw-semibold);
 }
 
@@ -565,13 +566,13 @@ select.control {
   color: var(--text);
 }
 .vsel-opt.sel {
-  color: var(--accent-bright);
+  color: var(--accent-text);
 }
 .vsel-check {
   width: 14px;
   display: inline-flex;
   justify-content: center;
-  color: var(--accent);
+  color: var(--accent-text);
   flex: none;
 }
 
@@ -621,7 +622,7 @@ select.control {
 }
 .scn-item.active {
   background: var(--accent-wash);
-  color: var(--accent-bright);
+  color: var(--accent-text);
   font-weight: var(--fw-medium);
   box-shadow: inset 2px 0 0 var(--accent);
 }
@@ -668,7 +669,7 @@ select.control {
   opacity: 1;
 }
 .adapter-item.celeris {
-  color: var(--accent-bright);
+  color: var(--accent-text);
 }
 .rail-actions {
   display: flex;
@@ -686,7 +687,7 @@ select.control {
   transition: color var(--dur-1), border-color var(--dur-1), background var(--dur-1);
 }
 .mini-btn:hover {
-  color: var(--accent-bright);
+  color: var(--accent-text);
   border-color: var(--border-accent);
   background: var(--accent-soft);
 }
@@ -764,7 +765,7 @@ select.control {
   opacity: 0.38;
 }
 .legend .lg-clear {
-  color: var(--accent-bright);
+  color: var(--accent-text);
   border: 1px solid var(--border-accent);
   font-weight: var(--fw-semibold);
 }

--- a/src/dashboard/views/HeadToHead.tsx
+++ b/src/dashboard/views/HeadToHead.tsx
@@ -91,7 +91,7 @@ export function HeadToHead() {
         .h2h-mid { text-align: center; }
         .h2h-scn { color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         .h2h-delta { font-weight: 600; font-variant-numeric: tabular-nums; }
-        .h2h-delta.up { color: var(--accent-bright); }
+        .h2h-delta.up { color: var(--accent-text); }
         .h2h-delta.down { color: var(--text-faint); }
       `}</style>
     </Panel>

--- a/src/dashboard/views/Matrix.tsx
+++ b/src/dashboard/views/Matrix.tsx
@@ -93,9 +93,9 @@ export function Matrix() {
         .matrix .corner { position: sticky; left: 0; top: 0; z-index: 3; background: var(--surface-2); padding: 4px 8px; text-align: left; color: var(--text-faint); }
         .matrix thead th.col-h { height: 116px; vertical-align: bottom; background: var(--surface-1); position: sticky; top: 0; z-index: 2; cursor: pointer; padding: 4px; }
         .matrix .rot { display: inline-block; writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap; color: var(--text-muted); max-height: 108px; overflow: hidden; }
-        .matrix th.col-h:hover .rot { color: var(--accent-bright); }
+        .matrix th.col-h:hover .rot { color: var(--accent-text); }
         .matrix tbody th.row-h { position: sticky; left: 0; z-index: 1; background: var(--surface-1); text-align: left; padding: 3px 8px; white-space: nowrap; color: var(--text-muted); }
-        .matrix tbody th.row-h.celeris { color: var(--accent-bright); }
+        .matrix tbody th.row-h.celeris { color: var(--accent-text); }
         .matrix tr.hl td, .matrix tr.hl th.row-h { outline: 1px solid var(--border-strong); }
         .matrix td.cell { width: 30px; height: 26px; text-align: center; position: relative; }
         .matrix td.cell.cel { box-shadow: inset 0 0 0 1px var(--border-accent); }

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -34,7 +34,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     font-weight: var(--fw-bold);
     line-height: 1;
     letter-spacing: -0.04em;
-    color: var(--accent-bright);
+    color: var(--accent-text);
     margin: 0;
   }
   .nf-title {

--- a/src/pages/benchmarks/index.astro
+++ b/src/pages/benchmarks/index.astro
@@ -23,6 +23,7 @@ const jsonLd = {
 >
   <Header solid />
   <main id="main" tabindex="-1" style="display: contents">
+    <h1 class="sr-only">Celeris benchmarks</h1>
     <Dashboard client:only="preact" />
   </main>
 </BaseLayout>

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -90,7 +90,7 @@ const nextHref = next ? href(next.id) : null;
         {
           groups.map((g) => (
             <nav class="group" aria-label={g.name}>
-              <h4><GroupIcon group={g.name} size={14} />{g.name}</h4>
+              <p class="group-t"><GroupIcon group={g.name} size={14} />{g.name}</p>
               {g.items.map((it) => (
                 <a href={href(it.id)} class:list={[{ active: it.id === currentId }]}>
                   {it.title}
@@ -137,7 +137,7 @@ const nextHref = next ? href(next.id) : null;
       {
         toc.length > 0 && (
           <>
-            <h4>On this page</h4>
+            <p class="toc-t">On this page</p>
             {toc.map((h) => (
               <a href={`#${h.slug}`} class:list={[h.depth === 3 ? "d3" : ""]}>
                 {h.text}

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -157,8 +157,8 @@ const jsonLd = {
     border: 1px solid var(--border-strong);
   }
   .hbtn.ghost:hover {
-    border-color: var(--accent);
-    color: var(--accent-bright);
+    border-color: var(--accent-text);
+    color: var(--accent-text);
   }
   .hbtn:focus-visible {
     outline: none;
@@ -202,7 +202,7 @@ const jsonLd = {
     border-radius: inherit;
   }
   .hub-card:hover .hub-card-go {
-    color: var(--accent-bright);
+    color: var(--accent-text);
   }
   @supports ((-webkit-mask-composite: xor) or (mask-composite: exclude)) {
     .hub-card {
@@ -273,7 +273,7 @@ const jsonLd = {
     border-radius: var(--r-md);
     background: var(--accent-wash);
     border: 1px solid var(--border-accent);
-    color: var(--accent-bright);
+    color: var(--accent-text);
     flex: none;
   }
   .hub-card-head h2 {
@@ -311,7 +311,7 @@ const jsonLd = {
     transition: color var(--dur-1), background var(--dur-1);
   }
   .hub-links a:hover {
-    color: var(--accent-bright);
+    color: var(--accent-text);
     background: var(--surface-2);
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -584,7 +584,7 @@ const jsonLd = [
   .lede { font-size: var(--fs-md); color: var(--text-muted); max-width: 60ch; line-height: var(--lh-snug); margin-top: 0; text-wrap: pretty; }
   .lede strong { color: var(--text); font-weight: var(--fw-semibold); }
   .hero-rotate { margin-top: var(--sp-4); display: flex; align-items: baseline; gap: 0.5ch; flex-wrap: wrap; font-family: var(--font-mono); font-size: var(--fs-sm); color: var(--text-muted); }
-  .hero-rotate .rotate { color: var(--accent-bright); font-weight: var(--fw-medium); }
+  .hero-rotate .rotate { color: var(--accent-text); font-weight: var(--fw-medium); }
   .caret { display: inline-block; width: 2px; height: 1em; background: var(--accent); transform: translateY(2px); animation: caret-blink 1.05s steps(1) infinite; }
   @keyframes caret-blink { 50% { opacity: 0; } }
   @media (prefers-reduced-motion: reduce) { .caret { display: none; } }
@@ -597,7 +597,7 @@ const jsonLd = [
   .pill:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--canvas), 0 0 0 4px var(--accent-bright); }
   @media (pointer: coarse) { .pill { min-height: 44px; padding-block: 0.6rem; } }
   .pill:hover { border-color: var(--border-accent); color: var(--text); background: var(--accent-soft); }
-  .pill b { color: var(--accent-bright); }
+  .pill b { color: var(--accent-text); }
   .pill .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px var(--accent); }
   .pill .arr { color: var(--text-faint); }
 
@@ -617,7 +617,7 @@ const jsonLd = [
     box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04);
     transition: background var(--dur-1) var(--ease), border-color var(--dur-1) var(--ease), color var(--dur-1) var(--ease), transform var(--dur-2) var(--ease);
   }
-  .btn.ghost:hover { background: linear-gradient(180deg, var(--surface-2), var(--surface-1)); border-color: var(--accent); color: var(--accent-bright); transform: translateY(-1px); }
+  .btn.ghost:hover { background: linear-gradient(180deg, var(--surface-2), var(--surface-1)); border-color: var(--accent-text); color: var(--accent-text); transform: translateY(-1px); }
   .btn.ghost:active { transform: translateY(0); }
   .btn:focus-visible { outline: 2px solid transparent; outline-offset: 2px; box-shadow: 0 0 0 2px var(--canvas), 0 0 0 4px var(--accent-bright), 0 4px 18px var(--accent-glow); }
   @media (prefers-reduced-motion: reduce) { .btn { transition: none; } .btn:hover, .btn:active { transform: none; } }
@@ -649,7 +649,7 @@ const jsonLd = [
   /* Extend the tap target to ~44px without growing the 30px chip visual. */
   .bench-flip::before { content: ""; position: absolute; inset: -7px; border-radius: inherit; }
   .bench-flip svg { transition: transform 0.5s var(--ease); }
-  .bench-flip:hover, .bench-flip:active, .bench-flip:focus-visible { color: var(--accent-bright); border-color: var(--border-accent); }
+  .bench-flip:hover, .bench-flip:active, .bench-flip:focus-visible { color: var(--accent-text); border-color: var(--border-accent); }
   .bench-flip:hover svg, .bench-flip:active svg { transform: rotate(180deg); }
   .bench-flip:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--canvas), 0 0 0 4px var(--accent-bright); }
   .bench-cap { display: flex; align-items: baseline; gap: var(--sp-3); margin-bottom: var(--sp-4); padding-bottom: var(--sp-3); padding-right: 2.2rem; border-bottom: 1px solid var(--border); }
@@ -662,9 +662,9 @@ const jsonLd = [
   .bench-bars:hover .bench-row:hover { opacity: 1; }
   .bench-name { display: flex; align-items: baseline; gap: 0.45ch; min-width: 0; color: var(--text-muted); }
   .bench-name .bn { font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .bench-name .bl { flex: none; font-size: var(--fs-3xs); color: var(--text-faint); }
-  .bench-row.win .bench-name .bn { color: var(--accent-bright); font-weight: var(--fw-semibold); }
-  .bench-row.win .bench-name .bl { color: var(--accent-dim); }
+  .bench-name .bl { flex: none; font-size: var(--fs-3xs); color: var(--text-muted); }
+  .bench-row.win .bench-name .bn { color: var(--accent-text); font-weight: var(--fw-semibold); }
+  .bench-row.win .bench-name .bl { color: var(--accent-text); }
   .bench-track { position: relative; height: 22px; background: var(--surface-3); border-radius: var(--r-xs); overflow: hidden; }
   .bench-fill { position: absolute; inset: 0 auto 0 0; width: var(--w); border-radius: var(--r-xs); background: var(--bar-neutral); transform-origin: left; overflow: hidden; transition: filter var(--dur-1) var(--ease); }
   .bench-row:hover .bench-fill { filter: brightness(1.12); }
@@ -679,9 +679,9 @@ const jsonLd = [
   @keyframes bench-sheen { 0%, 55% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
   @media (prefers-reduced-motion: reduce) { .bench-row.win .bench-fill::after { display: none; } }
   .bench-val { text-align: right; font-variant-numeric: tabular-nums; color: var(--text); font-weight: var(--fw-medium); }
-  .bench-row.win .bench-val { color: var(--accent-bright); font-weight: var(--fw-bold); }
+  .bench-row.win .bench-val { color: var(--accent-text); font-weight: var(--fw-bold); }
   .bench-kpi { display: flex; align-items: baseline; gap: 0.6rem; margin-top: var(--sp-4); padding-top: var(--sp-4); border-top: 1px solid var(--border); }
-  .kpi-n { font-size: var(--fs-2xl); font-weight: var(--fw-bold); color: var(--accent-bright); font-variant-numeric: tabular-nums; letter-spacing: -0.03em; line-height: 1; }
+  .kpi-n { font-size: var(--fs-2xl); font-weight: var(--fw-bold); color: var(--accent-text); font-variant-numeric: tabular-nums; letter-spacing: -0.03em; line-height: 1; }
   .kpi-l { font-size: var(--fs-2xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
 
   @media (prefers-reduced-motion: no-preference) {
@@ -724,13 +724,13 @@ const jsonLd = [
   .code-card :global(pre) { margin: 0; border: none; border-radius: 0; padding: var(--sp-5); }
 
   .install { display: flex; align-items: center; gap: 0.55rem; margin-top: var(--sp-5); padding: 0.6rem 0.6rem 0.6rem 1.1rem; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--surface-1); font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--text); }
-  .install .prompt { color: var(--accent); user-select: none; }
+  .install .prompt { color: var(--accent-text); user-select: none; }
   .install-cmd { flex: 1; overflow-x: auto; white-space: nowrap; scrollbar-width: none; }
   .install-cmd::-webkit-scrollbar { display: none; }
   .install-copy { flex: none; display: inline-grid; place-items: center; width: 30px; height: 30px; border-radius: var(--r-sm); border: 1px solid var(--border-strong); background: color-mix(in oklch, var(--surface-2) 80%, transparent); color: var(--text-muted); opacity: 0; transition: opacity var(--dur-1), color var(--dur-1), border-color var(--dur-1); }
   .install:hover .install-copy, .install-copy:focus-visible { opacity: 1; }
   .install-copy:hover { color: var(--text); border-color: var(--border-accent); }
-  .install-copy.done { color: var(--accent-bright); border-color: var(--border-accent); opacity: 1; }
+  .install-copy.done { color: var(--accent-text); border-color: var(--border-accent); opacity: 1; }
   @media (max-width: 520px) { .install-copy { opacity: 1; } }
 
   /* ---------- cards (gradient-hairline + premium surface) ---------- */
@@ -760,16 +760,16 @@ const jsonLd = [
   .card h3 { font-size: var(--h-card); margin-bottom: var(--sp-2); font-weight: var(--fw-semibold); position: relative; z-index: 2; }
   .card p { color: var(--text-muted); font-size: var(--fs-sm); position: relative; z-index: 2; }
   .card.engine header { display: flex; align-items: center; gap: 0.55rem; margin-bottom: var(--sp-3); position: relative; z-index: 2; }
-  .card.engine h3 { margin: 0; font-family: var(--font-mono); color: var(--accent-bright); }
+  .card.engine h3 { margin: 0; font-family: var(--font-mono); color: var(--accent-text); }
   .card.engine .chev { color: var(--accent-dim); flex: none; }
   .card.engine .tag { margin-left: auto; font-size: var(--fs-3xs); color: var(--text-faint); border: 1px solid var(--border); border-radius: var(--r-full); padding: 1px 8px; }
-  .card.engine.feature .tag { color: var(--accent-bright); border-color: var(--border-accent); background: var(--accent-wash); }
+  .card.engine.feature .tag { color: var(--accent-text); border-color: var(--border-accent); background: var(--accent-wash); }
 
   .feat-ico {
     position: relative; z-index: 2; display: inline-grid; place-items: center;
     width: 38px; height: 38px; margin-bottom: var(--sp-3);
     border-radius: var(--r-md); background: var(--accent-wash);
-    border: 1px solid var(--border-accent); color: var(--accent-bright);
+    border: 1px solid var(--border-accent); color: var(--accent-text);
   }
 
   .ticks { list-style: none; padding: 0; margin-top: var(--sp-4); display: flex; flex-direction: column; gap: var(--sp-2); }
@@ -782,10 +782,10 @@ const jsonLd = [
   /* ---------- validate ---------- */
   .validate { display: grid; grid-template-columns: 1.5fr 1fr; gap: clamp(1.5rem, 4vw, 3rem); align-items: center; border: 1px solid var(--border-accent); border-radius: var(--r-lg); padding: clamp(1.5rem, 4vw, 3rem); background: linear-gradient(120deg, var(--accent-wash), transparent); box-shadow: var(--edge-highlight), var(--shadow-3); }
   .validate h2 { font-size: var(--h2); letter-spacing: var(--tracking-head); margin-bottom: var(--sp-3); font-weight: var(--fw-semibold); }
-  .validate p a { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 2px; }
+  .validate p a { color: var(--accent-text); text-decoration: underline; text-underline-offset: 2px; }
   .validate .btn { margin-top: var(--sp-4); }
   .validate-stat { text-align: right; }
-  .validate-stat .big { font-size: clamp(2.4rem, 6vw, 4rem); font-weight: var(--fw-bold); color: var(--accent-bright); letter-spacing: -0.04em; line-height: 1; font-variant-numeric: tabular-nums; }
+  .validate-stat .big { font-size: clamp(2.4rem, 6vw, 4rem); font-weight: var(--fw-bold); color: var(--accent-text); letter-spacing: -0.04em; line-height: 1; font-variant-numeric: tabular-nums; }
 
   .final h2 { margin-bottom: var(--sp-5); }
 

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -227,7 +227,7 @@ const jsonLd = {
 
   /* callout */
   .callout { display: grid; gap: var(--sp-2); border: 1px solid var(--border-accent); border-left-width: 3px; border-radius: var(--r-md); background: linear-gradient(120deg, var(--accent-wash), transparent 60%); padding: var(--sp-5); margin-bottom: var(--sp-8); }
-  .callout-k { font-family: var(--font-mono); font-size: var(--fs-2xs); text-transform: uppercase; letter-spacing: var(--tracking-eyebrow); color: var(--accent-bright); }
+  .callout-k { font-family: var(--font-mono); font-size: var(--fs-2xs); text-transform: uppercase; letter-spacing: var(--tracking-eyebrow); color: var(--accent-text); }
   .callout p { color: var(--text-muted); font-size: var(--fs-sm); line-height: var(--lh-snug); }
 
   /* sections */
@@ -255,7 +255,7 @@ const jsonLd = {
   .node { border: 1px solid var(--border-strong); border-radius: var(--r-md); background: var(--surface-2); padding: var(--sp-4); text-align: center; box-shadow: var(--edge-highlight); }
   .node.srv { border-color: var(--border-accent); }
   .node-k { display: block; font-family: var(--font-mono); font-size: var(--fs-sm); color: var(--text); }
-  .node.srv .node-k { color: var(--accent-bright); }
+  .node.srv .node-k { color: var(--accent-text); }
   .node-d { display: block; font-size: var(--fs-2xs); color: var(--text-faint); margin-top: 2px; }
   .node-stack { display: grid; gap: var(--sp-3); }
   .wire { position: relative; min-width: 90px; text-align: center; }
@@ -288,12 +288,12 @@ const jsonLd = {
   /* families */
   .fam-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--sp-4); }
   @media (max-width: 520px) { .fam-grid { grid-template-columns: 1fr; } }
-  .fam-ico { position: relative; z-index: 2; display: inline-grid; place-items: center; width: 38px; height: 38px; margin-bottom: var(--sp-3); border-radius: var(--r-md); background: var(--accent-wash); border: 1px solid var(--border-accent); color: var(--accent-bright); }
+  .fam-ico { position: relative; z-index: 2; display: inline-grid; place-items: center; width: 38px; height: 38px; margin-bottom: var(--sp-3); border-radius: var(--r-md); background: var(--accent-wash); border: 1px solid var(--border-accent); color: var(--accent-text); }
 
   /* checks */
   .checks { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--sp-3); max-width: 72ch; }
   .checks li { display: grid; grid-template-columns: auto 1fr; gap: var(--sp-3); align-items: start; color: var(--text-muted); line-height: var(--lh-snug); }
-  .checks .ck { color: var(--accent-bright); margin-top: 2px; flex: none; }
+  .checks .ck { color: var(--accent-text); margin-top: 2px; flex: none; }
   .checks strong { color: var(--text); }
 
   /* cta */

--- a/src/styles/docs.css
+++ b/src/styles/docs.css
@@ -56,7 +56,7 @@
 .docs-side .group {
   margin-bottom: var(--sp-4);
 }
-.docs-side .group > h4 {
+.docs-side .group > .group-t {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -66,9 +66,9 @@
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);
   color: var(--text-faint);
-  margin-bottom: var(--sp-2);
+  margin: 0 0 var(--sp-2);
 }
-.docs-side .group > h4 svg {
+.docs-side .group > .group-t svg {
   color: var(--text-faint);
   flex: none;
 }
@@ -88,7 +88,7 @@
 .docs-side a.active {
   color: var(--accent-text);
   font-weight: var(--fw-medium);
-  border-left-color: var(--accent);
+  border-left-color: var(--accent-text);
   background: var(--accent-wash);
 }
 
@@ -153,7 +153,7 @@
   text-decoration-color: var(--border-accent);
 }
 .prose a:hover {
-  text-decoration-color: var(--accent);
+  text-decoration-color: var(--accent-text);
 }
 .prose :not(pre) > code {
   color: var(--text);
@@ -212,14 +212,14 @@
   top: calc(var(--header-h) + var(--sp-4));
   font-size: var(--fs-2xs);
 }
-.docs-toc h4 {
+.docs-toc .toc-t {
   font-family: var(--font-mono);
   font-size: var(--fs-3xs);
   font-weight: var(--fw-medium);
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);
   color: var(--text-faint);
-  margin-bottom: var(--sp-2);
+  margin: 0 0 var(--sp-2);
 }
 .docs-toc a {
   display: block;
@@ -316,7 +316,7 @@
   letter-spacing: var(--tracking-head);
 }
 .docs-nav a:hover .t {
-  color: var(--accent-bright);
+  color: var(--accent-text);
 }
 .docs-nav .next {
   text-align: right;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -265,7 +265,7 @@ pre.astro-code {
   border-color: var(--border-accent);
 }
 .code-copy.done {
-  color: var(--accent-bright);
+  color: var(--accent-text);
   border-color: var(--border-accent);
   opacity: 1;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -26,7 +26,7 @@
   /* ---- Text ---- */
   --text: oklch(0.96 0.006 256);
   --text-muted: oklch(0.74 0.012 256);
-  --text-faint: oklch(0.58 0.012 256);
+  --text-faint: oklch(0.66 0.012 256);
   --text-on-accent: oklch(0.16 0.03 150);
 
   /* popover/modal surface — one step above surface-3 for true floating overlays */
@@ -186,11 +186,15 @@
   --text-faint: oklch(0.5 0.012 256);
   --accent: oklch(0.62 0.18 142);
   --accent-bright: oklch(0.56 0.19 142);
-  /* darker green for normal-size text → ~5.6:1 on white (WCAG AA) */
-  --accent-text: oklch(0.5 0.17 142);
+  /* darker green for normal-size accent text — clears WCAG AA 4.5:1 with margin
+     on every light surface, incl. tinted/elevated cards (~5:1+). */
+  --accent-text: oklch(0.45 0.17 142);
   --accent-glow: oklch(0.62 0.18 142 / 0.16);
   --accent-soft: oklch(0.62 0.18 142 / 0.12);
-  --text-on-accent: oklch(0.99 0.02 150);
+  /* Dark ink on the bright-lime CTA: near-white failed WCAG AA on the medium
+     light-mode lime (~3.3:1); near-black clears it (~4.8:1 at the gradient's
+     darker end). */
+  --text-on-accent: oklch(0.13 0.03 150);
   /* light-tuned elevation: softer, cooler than the dark drops */
   --shadow-1: 0 1px 2px oklch(0.4 0.02 256 / 0.12);
   --shadow-2: 0 10px 34px oklch(0.4 0.03 256 / 0.16);


### PR DESCRIPTION
Lighthouse audit (desktop + mobile, all pages) — corrected every real Accessibility finding, verified by an in-browser OKLCH contrast sweep in **both themes** on landing, docs hub, docs articles (code/tables/lists), methodology, benchmarks, and 404.

## Contrast (WCAG 1.4.3)
- **`--text-faint`** failed on dark surfaces (3.5–4.4:1). Lightened `0.58 → 0.66` (clears 4.5:1 on every dark surface, still below `--text-muted`). Fixes `.idx` eyebrows, dashboard labels, line/lang labels, etc.
- **Accent-as-text** failed on light backgrounds (engine `h3`s, rotating word, winning bench bars, links, terminal prompt). Migrated all `color: var(--accent-bright|--accent)` → `--accent-text` — a **no-op in dark** (there `--accent-text`==`--accent-bright`), a **fix in light**. Darkened light `--accent-text` `0.5 → 0.45` for margin on tinted/elevated cards.
- **Primary CTA**: light `--text-on-accent` was near-white on the lime gradient (~3.3:1) → near-black ink (~4.8:1).

## Heading order (heading-order / page-has-heading-one)
- Footer column titles, docs sidebar group labels, docs TOC label were `<h4>` (chrome inside aria-labelled landmarks) → styled `<p>`, so the outline is pure content (h1→h2→h3, no skips).
- Benchmarks had **no `<h1>`** and opened at `<h3>`: added a visually-hidden `<h1>`; ControlRail rail labels `<h3>`→`<h2>`.

## Notes
- The only remaining contrast "hit" is the **`aria-disabled` "arm64 coming soon"** toggle — exempt from 1.4.3 (inactive component) and not flagged by Lighthouse.
- Perf was already strong (LCP 0.4s, all metrics green; Inter LCP font preloaded; immutable asset caching shipped earlier). The report's "unused JS — 43 KiB" is a `chrome-extension://…` script (a browser extension), not site code.

## Verified
- 0 contrast failures on every page, dark + light
- Heading outlines sequential on all pages
- `bun run check` 0 errors · `bun test` 16/16 · `bun run build` clean