### PR TITLE
feat(landing): add lithium, h2o, netty to the hero chart

### DIFF
--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -164,10 +164,11 @@ export function heroBars(): { scenario: string; bars: HeroBar[] } | null {
     if (!best) return null;
     const scn = best.scn;
 
-    // Celeris (best engine) vs a recognizable mix of FULL frameworks — the fast
-    // exotics (actix/drogon), popular Go (fiber/gin), and the mainstream Python/
-    // Node frameworks everyone knows (FastAPI/Express). Low-level libs
-    // (gnet/h2o/lithium/uWS/fasthttp) are excluded — they aren't full frameworks.
+    // Celeris (best engine) vs a recognizable cross-language field: the fastest
+    // C/C++ servers (lithium, h2o), the fast exotics (actix/drogon), the best
+    // Java framework (netty), popular Go (fiber/gin), and the mainstream Python/
+    // Node names everyone knows (FastAPI/Express). Celeris still tops them all —
+    // beating even the hand-tuned C/C++ libraries is the point of the chart.
     const celRps = best.cel;
     // The specific Celeris engine that achieved the peak — used for its timeseries.
     let celId = "";
@@ -177,8 +178,11 @@ export function heroBars(): { scenario: string; bars: HeroBar[] } | null {
       if (v != null && Math.round(v) === Math.round(celRps)) celId = id;
     }
     const CURATED = [
+      { id: "lithium", name: "lithium", lang: "C++" },
+      { id: "h2o", name: "h2o", lang: "C" },
       { id: "actix", name: "actix", lang: "Rust" },
       { id: "drogon", name: "drogon", lang: "C++" },
+      { id: "netty", name: "netty", lang: "Java" },
       { id: "fiber-h1", name: "fiber", lang: "Go" },
       { id: "gin-h1", name: "gin", lang: "Go" },
       { id: "fastapi", name: "FastAPI", lang: "Python" },


### PR DESCRIPTION
Broadens the landing hero chart (throughput + latency flip) to a full cross-language field, per request — making Celeris' lead more impressive.

Added (all from the live v1.5.5 `get-simple-1024c` payload, nothing synthetic):
- **lithium** (C++) — 1.25M
- **h2o** (C) — 1.22M
- **netty** (Java) — 1.07M (the faster Java framework; vertx is 0.97M)

Celeris still **tops every bar**: 1.37M RPS and 1.2ms p99 — now beating the hand-tuned C/C++ servers and the best Java framework, not just the Go/exotic field. No existing rows removed.

Verified: chart renders 11 frameworks, Celeris leads throughput **and** latency, no mobile overflow (390px), `bun run build` + `bun run check` (0 errors) clean.