### PR TITLE
feat(seo): llms.txt + llms-full.txt for AI agents

### DIFF
--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,64 @@
+import type { APIRoute } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+
+// /llms-full.txt — the entire user documentation concatenated as Markdown, so an
+// LLM or agent can ingest the whole corpus in a single fetch. Built from the
+// docs collection so it stays in sync with the site.
+
+type Doc = CollectionEntry<"docs">;
+
+const SITE = (import.meta.env.SITE ?? "https://goceleris.dev").replace(/\/$/, "");
+const GROUP_ORDER = [
+  "Getting Started",
+  "Routing & Handlers",
+  "Middleware",
+  "Real-Time",
+  "Data & Integration",
+  "Reference",
+  "Operations",
+];
+
+const rank = (g: string) => {
+  const i = GROUP_ORDER.indexOf(g);
+  return i === -1 ? 99 : i;
+};
+
+export const GET: APIRoute = async () => {
+  const all = (await getCollection("docs")).filter((d: Doc) => !d.data.draft);
+  const sorted = [...all].sort(
+    (a: Doc, b: Doc) =>
+      rank(a.data.group) - rank(b.data.group) ||
+      a.data.order - b.data.order ||
+      a.data.title.localeCompare(b.data.title),
+  );
+
+  const out: string[] = [];
+  out.push("# Celeris — full documentation");
+  out.push("");
+  out.push(
+    "> Celeris is a high-performance HTTP engine for Go (io_uring / epoll, with a standard-library fallback) that keeps a Gin/Echo-style routing and middleware API. This file concatenates the complete user documentation as Markdown for LLMs and agents.",
+  );
+  out.push("");
+  out.push(`Source: ${SITE} · Benchmarks: ${SITE}/benchmarks · Methodology: ${SITE}/methodology`);
+  out.push("");
+
+  for (const d of sorted) {
+    out.push("");
+    out.push("---");
+    out.push("");
+    out.push(`# ${d.data.title}`);
+    out.push("");
+    if (d.data.description) {
+      out.push(`> ${d.data.description}`);
+      out.push("");
+    }
+    out.push(`Source: ${SITE}/docs/${d.id}`);
+    out.push("");
+    out.push((d.body ?? "").trim());
+    out.push("");
+  }
+
+  return new Response(out.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+
+// /llms.txt — a curated, LLM-friendly map of the site (https://llmstxt.org/).
+// Generated from the docs collection at build time so it never drifts.
+
+type Doc = CollectionEntry<"docs">;
+
+const SITE = (import.meta.env.SITE ?? "https://goceleris.dev").replace(/\/$/, "");
+const GROUP_ORDER = [
+  "Getting Started",
+  "Routing & Handlers",
+  "Middleware",
+  "Real-Time",
+  "Data & Integration",
+  "Reference",
+  "Operations",
+];
+
+export const GET: APIRoute = async () => {
+  const all = (await getCollection("docs")).filter((d: Doc) => !d.data.draft);
+  const groups = GROUP_ORDER.map((name) => ({
+    name,
+    items: all
+      .filter((d: Doc) => d.data.group === name)
+      .sort((a: Doc, b: Doc) => a.data.order - b.data.order),
+  })).filter((g) => g.items.length > 0);
+
+  const out: string[] = [];
+  out.push("# Celeris");
+  out.push("");
+  out.push(
+    "> Celeris is a high-performance HTTP engine for Go. It replaces the standard net/http server with its own asynchronous I/O core — io_uring or epoll on Linux, with an automatic standard-library fallback everywhere else — while keeping a routing and middleware API you already know from Gin and Echo.",
+  );
+  out.push("");
+  out.push(
+    "This is the goceleris.dev documentation site. Every page is plain, static HTML and crawling is welcome (see /robots.txt). For the entire documentation as one Markdown document, fetch " +
+      `${SITE}/llms-full.txt.`,
+  );
+  out.push("");
+
+  for (const g of groups) {
+    out.push(`## ${g.name}`);
+    out.push("");
+    for (const it of g.items) {
+      const desc = it.data.description ? `: ${it.data.description}` : "";
+      out.push(`- [${it.data.title}](${SITE}/docs/${it.id})${desc}`);
+    }
+    out.push("");
+  }
+
+  out.push("## Benchmarks");
+  out.push("");
+  out.push(
+    `- [Benchmarks dashboard](${SITE}/benchmarks): Interactive throughput, latency-at-SLO, tail latency, memory and CPU for Celeris vs competitor frameworks across languages, averaged over every cluster run per release.`,
+  );
+  out.push(
+    `- [Methodology](${SITE}/methodology): How the benchmark numbers are produced — the cluster, the two run modes (saturation and rated), the signals measured, and the fairness rules.`,
+  );
+  out.push("");
+
+  out.push("## Optional");
+  out.push("");
+  out.push(`- [Full documentation (one file)](${SITE}/llms-full.txt): Every doc page concatenated as Markdown.`);
+  out.push(`- [Source — celeris](https://github.com/goceleris/celeris): The engine source on GitHub.`);
+  out.push("");
+
+  return new Response(out.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};


### PR DESCRIPTION
Adds the two AI/agent discovery files, generated from the docs collection at build time (so they never drift).

- **/llms.txt** — curated [llmstxt.org](https://llmstxt.org/) map: one-line summary, every doc grouped with title + description links, the benchmarks dashboard + methodology, and an optional section linking llms-full.txt and the source repo.
- **/llms-full.txt** — the entire user documentation concatenated as Markdown (~15.7k lines) for single-fetch ingestion.

Context: robots.txt was already permissive (`Allow: /` for all user-agents, only `/data/` excluded) and a sitemap is published — this completes the picture so agents/LLMs can fully discover and ingest the site.

Verified: both render at build, `/llms-full.txt` contains real doc bodies, `bun run check` 0 errors, `bun run build` clean. Served as `text/plain` (Workers Static Assets, by extension).