### PR TITLE
fix(landing): disambiguate the Go win-rate hero stat

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -195,7 +195,7 @@ const jsonLd = [
       <div class="stats">
         {stat ? (
           <>
-            <div class="stat"><div class="n">{stat.goWinRate}</div><div class="l">fastest Go framework</div></div>
+            <div class="stat" title={`Celeris is the fastest Go framework in ${stat.goWinRate} benchmarked scenarios.`}><div class="n"><span class="upto">fastest in</span>{stat.goWinRate}</div><div class="l">Go scenarios</div></div>
             {stat.goMaxMarginPct != null && (
               <div
                 class="stat"


### PR DESCRIPTION
"**26/29** / fastest Go framework" read like a *26th-of-29* ranking. Reframed with a small `fastest in` qualifier (mirroring the adjacent `up to +113%` stat) so it reads **"fastest in 26/29 / Go scenarios"** — Celeris is the fastest Go framework in 26 of 29 scenarios, not the 26th-fastest. Also matches the hero eyebrow wording ("Fastest Go framework in 26/29 scenarios"). Added a `title` tooltip spelling it out.

Verified in-browser (superscript stays on one line, no wrap), `bun run build` + `bun run check` clean.