### PR TITLE
fix(landing): disambiguate the Go win-rate hero stat

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -195,7 +195,7 @@ const jsonLd = [
       <div class="stats">
         {stat ? (
           <>
-            <div class="stat"><div class="n">{stat.goWinRate}</div><div class="l">fastest Go framework</div></div>
+            <div class="stat" title={`Celeris is the fastest Go framework in ${stat.goWinRate} benchmarked scenarios.`}><div class="n">{stat.goWinRate}</div><div class="l">Go scenarios won</div></div>
             {stat.goMaxMarginPct != null && (
               <div
                 class="stat"


### PR DESCRIPTION
"**26/29** / fastest Go framework" read like a *26th-of-29* ranking. Relabelled to **"26/29 / Go scenarios won"** — the number stays compact (consistent with the other three stats, no ragged overflow over a short label), and "won" makes it clear Celeris is fastest in 26 of 29 Go scenarios, not the 26th-fastest. Kept a `title` tooltip spelling it out.

Verified in-browser: balanced with the other stats, no overflow; `bun run build` + `bun run check` clean.