### PR TITLE
fix(landing): compact Go win-rate stat (no overflow)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -195,7 +195,7 @@ const jsonLd = [
       <div class="stats">
         {stat ? (
           <>
-            <div class="stat" title={`Celeris is the fastest Go framework in ${stat.goWinRate} benchmarked scenarios.`}><div class="n"><span class="upto">fastest in</span>{stat.goWinRate}</div><div class="l">Go scenarios</div></div>
+            <div class="stat" title={`Celeris is the fastest Go framework in ${stat.goWinRate} benchmarked scenarios.`}><div class="n">{stat.goWinRate}</div><div class="l">Go scenarios won</div></div>
             {stat.goMaxMarginPct != null && (
               <div
                 class="stat"


### PR DESCRIPTION
Follow-up to #48. The `fastest in` superscript made the number row wider than its short label, so the number looked like it overflowed the caption. This keeps the number **compact** (consistent with the other three hero stats) and moves the meaning to the label: **"26/29 / Go scenarios won"** — unambiguous (26 of 29 won, not 26th-of-29) and balanced. Tooltip retained.

Verified in-browser + `bun run build`/`check` clean.