### PR TITLE
docs(data): v1.5.6 refresh + Versions trend

### DIFF
--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -15,7 +15,7 @@ name is Latin for *swift*.
 import "github.com/goceleris/celeris"
 ```
 
-The current release is **[`v1.5.5`](https://github.com/goceleris/celeris/releases/latest)** —
+The current release is **[`v1.5.6`](https://github.com/goceleris/celeris/releases/latest)** —
 always pull the [latest release](https://github.com/goceleris/celeris/releases/latest)
 from GitHub.
 
@@ -143,7 +143,7 @@ Operations. If you just want to ship, jump straight to
 
 - **Module:** `github.com/goceleris/celeris` · **package:** `celeris`.
 - **Version:** the running version is the exported `celeris.Version` constant
-  (currently `1.5.5`). Pin a version in your `go.mod` and upgrade deliberately.
+  (currently `1.5.6`). Pin a version in your `go.mod` and upgrade deliberately.
 - **Go toolchain:** Go 1.26.4+ (the module targets `go 1.26.4`).
 - **Platforms:** Linux for io_uring/epoll/adaptive; any OS Go supports for the
   std engine. The engine choice is automatic unless you set


### PR DESCRIPTION
v1.5.6 benchmark data was published to `results/` (already live via the automated Workers Build). Analysis:

- **Pure data refresh** — identical 29 scenarios / 52 adapters / schema 5.5 / rig ("3-host LACP 20G") as v1.5.5, so no taxonomy/methodology/PREFERRED_SCENARIOS edits needed; everything data-driven auto-updates.
- Hero: **1.39M peak** (v1.5.5 was 1.37M, +0.8%), **25/29 Go scenarios won** (was 26/29). Dashboard defaults to v1.5.6.
- **Kept v1.5.5 alongside v1.5.6** so the dashboard **Versions view** now shows the real v1.5.5→v1.5.6 trend (was a single-version empty state). Additive/reversible — say the word for latest-only.

Only hand-edit: current-release version string in `introduction.md` (v1.5.5 → v1.5.6).

Verified: `build:data` 2 versions/0 warnings, `bun run build`/`check` 0 errors, 16/16 tests, benchmarks default v1.5.6, Versions trend renders, landing shows v1.5.6 numbers.