### PR TITLE
feat(dashboard): redesign the Versions trend view

### DIFF
--- a/src/dashboard/views/Versions.tsx
+++ b/src/dashboard/views/Versions.tsx
@@ -1,67 +1,144 @@
 import { useEffect, useState } from "preact/hooks";
-import type uPlot from "uplot";
 import { arch, scenario, versionsList, warmAllVersions, cachedPayload, payload } from "../state";
 import { Panel, CenterNote } from "../components/Panel";
-import UplotChart, { axisDefaults } from "../charts/UplotChart";
-import { celerisIds, adapterColor, adapterShort, scenarioName } from "../registry";
+import { celerisIds, scenarioName } from "../registry";
 import { fmtRps } from "../format";
+
+/* One line per Celeris engine family (best variant of each), tracing saturation
+   RPS across releases. Distinct, theme-aware colors + a value/delta legend, so
+   the per-engine evolution (e.g. a big adaptive jump) is legible at a glance. */
+const FAMILY_DEFS = [
+  { key: "iouring", label: "io_uring", color: "var(--vt-iouring)" },
+  { key: "epoll", label: "epoll", color: "var(--vt-epoll)" },
+  { key: "adaptive", label: "adaptive", color: "var(--vt-adaptive)" },
+  { key: "std", label: "std", color: "var(--vt-std)" },
+];
+
+const pct = (a: number, b: number) => ((b - a) / a) * 100;
+const fmtPct = (p: number) => (Math.abs(p) < 0.05 ? "±0%" : (p > 0 ? "+" : "−") + Math.abs(p).toFixed(1) + "%");
+function niceMax(v: number) {
+  const p = Math.pow(10, Math.floor(Math.log10(v)));
+  const n = v / p;
+  const m = n <= 1 ? 1 : n <= 1.2 ? 1.2 : n <= 1.5 ? 1.5 : n <= 2 ? 2 : n <= 2.5 ? 2.5 : n <= 3 ? 3 : n <= 4 ? 4 : n <= 5 ? 5 : 10;
+  return m * p;
+}
 
 export function Versions() {
   const [, force] = useState(0);
   useEffect(() => {
     void warmAllVersions().then(() => force((n) => n + 1));
   }, [arch.value]);
+  void payload.value;
 
   const scn = scenario.value;
-  // ascending order for a left→right trend
-  const versions = [...versionsList.value].reverse();
+  const A = arch.value;
+  const versions = [...versionsList.value].reverse(); // ascending, e.g. v1.5.5 → v1.5.6
+
   if (versions.length < 2) {
     return (
       <Panel title="Version trend">
         <CenterNote>
           <h2>Trend appears with a second version</h2>
-          <p>Once another celeris version is published, this charts throughput across releases.</p>
+          <p>Once another Celeris version is published, this charts throughput across releases.</p>
         </CenterNote>
       </Panel>
     );
   }
 
   const cels = celerisIds();
-  const xs = versions.map((_, i) => i);
-  const series: uPlot.Series[] = [{ label: "version" }];
-  const ys: (number | null)[][] = [];
-  for (const id of cels) {
-    const y = versions.map((v) => cachedPayload(v, arch.value)?.servers[id]?.scenarios[scn]?.saturation_rps?.mean ?? null);
-    if (y.every((v) => v == null)) continue;
-    ys.push(y);
-    series.push({ label: adapterShort(id), stroke: adapterColor(id), width: 2.2, points: { show: true, size: 6 } });
-  }
-
-  const ax = axisDefaults();
-  const data = [xs, ...ys] as uPlot.AlignedData;
-  const opts: Omit<uPlot.Options, "width" | "height"> = {
-    scales: { x: { time: false } },
-    legend: { show: false },
-    axes: [
-      { ...ax, values: (_u, vals) => vals.map((v) => versions[v] ?? "") } as uPlot.Axis,
-      { ...ax, values: (_u, vals) => vals.map((v) => fmtRps(v)) } as uPlot.Axis,
-    ],
-    series,
+  const rpsOf = (id: string, vi: number) =>
+    cachedPayload(versions[vi], A)?.servers[id]?.scenarios[scn]?.saturation_rps?.mean ?? null;
+  const maxOf = (ids: string[], vi: number) => {
+    const vals = ids.map((id) => rpsOf(id, vi)).filter((v): v is number => v != null && isFinite(v));
+    return vals.length ? Math.max(...vals) : null;
   };
 
+  const families = FAMILY_DEFS.map((f) => ({
+    ...f,
+    ys: versions.map((_, vi) => maxOf(cels.filter((id) => id.includes(f.key)), vi)),
+  })).filter((f) => f.ys.some((v) => v != null));
+
+  const title = `Version trend · ${scenarioName(scn)}`;
+  const sub = `best RPS per Celeris engine across releases · ${A}`;
+  if (families.length === 0) {
+    return (
+      <Panel title={title} sub={sub}>
+        <CenterNote>No Celeris data for this scenario across versions.</CenterNote>
+      </Panel>
+    );
+  }
+
+  // ---- geometry ----
+  const W = 960;
+  const H = 440;
+  const pad = { l: 78, r: 184, t: 40, b: 48 };
+  const pw = W - pad.l - pad.r;
+  const ph = H - pad.t - pad.b;
+  const n = versions.length;
+  const latest = n - 1;
+  const X = (vi: number) => pad.l + (n === 1 ? pw / 2 : (vi / (n - 1)) * pw);
+  const yMax = niceMax(Math.max(...families.flatMap((f) => f.ys).filter((v): v is number => v != null)) * 1.06);
+  const Y = (v: number) => pad.t + ph - (v / yMax) * ph;
+  const ticks = [0, 1, 2, 3, 4].map((i) => (yMax / 4) * i);
+  const linePath = (ys: (number | null)[]) =>
+    ys.map((v, vi) => (v == null ? "" : `${vi === 0 ? "M" : "L"}${X(vi)},${Y(v)}`)).join(" ");
+  const lx = pad.l + pw + 30;
+
   return (
-    <Panel
-      title={`Version trend · ${scenarioName(scn)}`}
-      sub={`saturation RPS across releases (${arch.value})`}
-    >
-      {ys.length === 0 ? (
-        <CenterNote>No celeris data for this scenario across versions.</CenterNote>
-      ) : (
-        <div style={{ height: "100%", minHeight: "340px" }}>
-          <UplotChart data={data} options={opts} />
-        </div>
-      )}
-      {void payload.value}
+    <Panel title={title} sub={sub}>
+      <div style={{ height: "100%", minHeight: "360px", display: "flex" }}>
+        <svg viewBox={`0 0 ${W} ${H}`} width="100%" height="100%" preserveAspectRatio="xMidYMid meet" style={{ display: "block" }}>
+          {/* grid + axes */}
+          {ticks.map((t) => (
+            <g key={t}>
+              <line x1={pad.l} y1={Y(t)} x2={pad.l + pw} y2={Y(t)} stroke="var(--border)" stroke-width="1" opacity={t === 0 ? 0.9 : 0.4} />
+              <text x={pad.l - 12} y={Y(t)} text-anchor="end" dominant-baseline="middle" font-family="var(--font-mono)" font-size="12.5" fill="var(--text-faint)">
+                {fmtRps(t)}
+              </text>
+            </g>
+          ))}
+          {versions.map((v, vi) => (
+            <text key={v} x={X(vi)} y={pad.t + ph + 27} text-anchor="middle" font-family="var(--font-mono)" font-size="13.5" font-weight="500" fill="var(--text-muted)">
+              {v}
+            </text>
+          ))}
+
+          {/* engine lines */}
+          {families.map((f) => (
+            <path key={f.key} d={linePath(f.ys)} fill="none" stroke={f.color} stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" />
+          ))}
+          {families.map((f) =>
+            f.ys.map((v, vi) =>
+              v == null ? null : <circle key={f.key + vi} cx={X(vi)} cy={Y(v)} r="4.6" fill="var(--surface-1)" stroke={f.color} stroke-width="2.8" />,
+            ),
+          )}
+
+          {/* legend: swatch · engine · latest value · release delta */}
+          {families.map((f, i) => {
+            const fy = pad.t + 10 + i * 40;
+            const a = f.ys.find((v) => v != null) ?? null;
+            const b = f.ys[latest];
+            const d = a != null && b != null ? pct(a, b) : null;
+            const up = d != null && d >= 0.05;
+            return (
+              <g key={f.key}>
+                <rect x={lx} y={fy} width="15" height="15" rx="3.5" fill={f.color} />
+                <text x={lx + 24} y={fy + 7.5} dominant-baseline="middle" font-family="var(--font-mono)" font-size="13.5" fill="var(--text)">
+                  {f.label}
+                </text>
+                <text x={lx + 24} y={fy + 26} dominant-baseline="middle" font-family="var(--font-mono)" font-size="12.5" fill="var(--text-muted)">
+                  {b != null ? fmtRps(b) : "—"}
+                  {d != null && (
+                    <tspan dx="8" font-weight="700" fill={up ? "var(--accent-text)" : "var(--text-faint)"}>
+                      {fmtPct(d)}
+                    </tspan>
+                  )}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
     </Panel>
   );
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -44,6 +44,14 @@
   /* hover tint, distinct from the flatter --accent-wash */
   --accent-soft: oklch(0.86 0.21 142 / 0.16);
 
+  /* Engine-family series colors for the Versions trend (dark: bright on canvas).
+     io_uring rides the brand accent; the others are distinct hues. Light-mode
+     overrides below keep them ≥3:1 on white. */
+  --vt-iouring: var(--accent-bright);
+  --vt-epoll: oklch(0.82 0.13 205);
+  --vt-adaptive: oklch(0.78 0.16 305);
+  --vt-std: oklch(0.82 0.07 80);
+
   /* secondary accent — a real second DATA color (cool cyan), not just gradients */
   --accent-2: oklch(0.82 0.13 220);
   --accent-2-bright: oklch(0.88 0.13 218);
@@ -191,6 +199,11 @@
   --accent-text: oklch(0.45 0.17 142);
   --accent-glow: oklch(0.62 0.18 142 / 0.16);
   --accent-soft: oklch(0.62 0.18 142 / 0.12);
+  /* Versions-trend series — darkened so each line clears ~3:1 on white. */
+  --vt-iouring: oklch(0.55 0.19 142);
+  --vt-epoll: oklch(0.52 0.13 235);
+  --vt-adaptive: oklch(0.5 0.19 305);
+  --vt-std: oklch(0.6 0.1 75);
   /* Dark ink on the bright-lime CTA: near-white failed WCAG AA on the medium
      light-mode lime (~3.3:1); near-black clears it (~4.8:1 at the gradient's
      darker end). */


### PR DESCRIPTION
The Versions view needed a lot of work — the old chart drew all **9 Celeris engines as identical green lines** (uPlot) with no legend, no values, no deltas: an unreadable tangle, worse with only 2 releases.

I prototyped **three** approaches in the real dashboard and picked the best by feel:
- **A — focused single line** (best engine + rival ref): cleanest, but hides per-engine detail.
- **B — per-engine trend** ✅ *chosen*: one line per engine family (io_uring / epoll / adaptive / std), distinct theme-aware colors, legend with latest RPS + release delta. Most informative, and it surfaces the real story — **adaptive +15.3%** (1.19M→1.37M) while io_uring holds the top.
- **C — grouped bars**: clear deltas but sparse with few releases, less trend-scalable.

Bespoke SVG (full control over labels/deltas/legend vs uPlot for a few points). Adds theme-aware `--vt-*` engine tokens (darkened in light mode for ≥3:1 on white).

Verified in-browser in **dark and light** (legible in both), `bun run build`/`check` 0 errors, 16/16 tests.