### PR TITLE
docs: v1.5.6 adaptive bidirectional transplant + freshness

### DIFF
--- a/src/content/docs/configuration.md
+++ b/src/content/docs/configuration.md
@@ -144,11 +144,13 @@ the `Std`/`Epoll`/`IOUring` engines.
 | `celeris.WorkloadHighConcurrency`  | Many H1 keep-alive conns/worker — start on io_uring (when kernel + `RLIMIT_MEMLOCK` allow) |
 
 Defined in `celeris/config.go:43-60` and `celeris/resource/resource.go:1-25`.
-Because established connections cannot migrate between epoll and io_uring, the
-*start* engine fixes keep-alive throughput, and concurrency is unknowable when the
-server binds (no connections exist yet). `WorkloadHighConcurrency` is the only way
-to make `Adaptive` *start* on io_uring; otherwise it ramps from epoll and promotes
-new connections under sustained load.
+Since v1.5.6 established connections **transplant** between epoll and io_uring when
+Adaptive switches (both directions), so the *start* engine no longer fixes
+keep-alive throughput — but concurrency is unknowable when the server binds (no
+connections exist yet), so a good start still avoids an unnecessary early switch.
+`WorkloadHighConcurrency` makes `Adaptive` *start* on io_uring; otherwise it ramps
+from epoll and switches to io_uring under sustained load, carrying its established
+keep-alives across.
 
 ```go
 celeris.Config{

--- a/src/content/docs/engines.md
+++ b/src/content/docs/engines.md
@@ -49,12 +49,20 @@ engine when the workload crosses a load threshold. You get the best engine for t
 box and the moment without choosing. See [The adaptive
 controller](#the-adaptive-controller) below for the signals it uses.
 
-Because connections cannot migrate between epoll and io_uring once accepted, the
-*start* engine matters for long-lived keep-alive throughput. By default Adaptive
-**starts on epoll** (best for the ramp-from-zero, low-concurrency, latency case)
-and promotes *new* connections to io_uring under sustained high load. The two ways
-to influence the start engine are the `WorkloadHint` config field (see below) and
-the `CELERIS_ADAPTIVE_START` env override (`epoll` | `iouring` | `auto`), an
+By default Adaptive **starts on epoll** (best for the ramp-from-zero,
+low-concurrency, latency case) and switches to io_uring under sustained high load.
+As of **v1.5.6**, a switch isn't only for *new* connections: established HTTP/1
+keep-alive connections are **transplanted** between the engines at clean request
+boundaries, in **both** directions — epoll→io_uring on promote and io_uring→epoll
+on revert — so a busy connection is never stranded on the slower engine. (Detached
+connections — WebSocket and SSE — are excluded by construction, since a connection
+only migrates at a fully-flushed request boundary.) This is what lets Adaptive
+actually reach io_uring's high-concurrency throughput — around io_uring parity,
+roughly **+15% over epoll at 1024 connections** — instead of forfeiting the win to
+keep-alives pinned on the standby.
+
+Two knobs influence the *start* engine: the `WorkloadHint` config field (see below)
+and the `CELERIS_ADAPTIVE_START` env override (`epoll` | `iouring` | `auto`), an
 operator escape hatch that pins the start engine and disables runtime switching.
 
 ### Epoll
@@ -151,23 +159,27 @@ actually drive the decision are:
 | **Bytes per request**   | `(BytesRead + BytesWritten) / RequestCount`   | Large-payload (>8 KB avg) traffic is link-bound — the engines tie — so an io_uring switch is *suppressed*. |
 | **Error rate**          | `ErrorCount` over time                         | If io_uring starts erroring on this host, a safety revert to epoll fires regardless of load. |
 
-Switching is **measured-vs-measured** and intentionally asymmetric. While epoll is
-active, a sustained high conns-per-worker reading promotes *new* connections to
-io_uring (an immediate snap past a heavy-load high-watermark, otherwise after a
-short sustain). Once on io_uring it stays there: because established connections
-are pinned and cannot migrate, the controller does **not** load-revert to epoll on
-a load dip (that would only strand io_uring keep-alives) — the only thing that
-reverts it is the io_uring error-rate safety net. Switching is gated by kernel,
+Switching is **measured-vs-measured** and **bidirectional**. While epoll is active,
+a sustained high conns-per-worker reading switches up to io_uring — an immediate
+snap past a heavy-load high-watermark, otherwise after a short sustain. While
+io_uring is active, conns-per-worker sustaining below a lower *down* threshold
+reverts to epoll; the gap between the up and down thresholds is a hysteresis band
+that prevents flapping. Either way the active engine's established keep-alive
+connections are **transplanted** to the new engine (see [Adaptive](#adaptive--the-default-on-linux)
+above), so a switch captures the throughput instead of stranding live connections.
+A separate, always-on error-rate safety revert fires if io_uring starts erroring,
+regardless of load. Switching is gated by kernel,
 `RLIMIT_MEMLOCK`, and protocol viability, and is damped against oscillation: after
 three switches in five minutes the controller locks the active engine for five
 minutes, plus a post-switch cooldown, so a borderline workload does not thrash.
 
 ### `WorkloadHint` — picking the start engine
 
-Because a connection cannot migrate between epoll and io_uring, the **start**
-engine fixes the keep-alive throughput ceiling for connections opened early — and
-the steady-state concurrency is unknowable when the server binds. `WorkloadHint`
-(`celeris/config.go:43-60`) is the *only* way to influence that start decision. It
+Established connections now transplant between engines on a switch (see above), so
+the **start** engine no longer fixes the keep-alive throughput ceiling — but the
+steady-state concurrency is still unknowable when the server binds, and a good
+start avoids an unnecessary early switch. `WorkloadHint`
+(`celeris/config.go:43-60`) is the config-level way to bias that start decision. It
 affects **nothing but the Adaptive engine's start choice**; on Epoll, IOUring, and
 Std it is ignored.
 

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -31,8 +31,9 @@ stdlib server. Underneath your routes sits a custom event loop:
 
 - **On Linux** it runs a tiered **io_uring** engine (kernel 5.10+, richer
   features on 5.19+) or an edge-triggered **epoll** engine with per-core CPU
-  pinning. The default **adaptive** engine starts on epoll and promotes
-  connections to io_uring under sustained load.
+  pinning. The default **adaptive** engine starts on epoll and switches to
+  io_uring under sustained load, transplanting live keep-alive connections
+  between the two in both directions.
 - **On every other platform** (macOS, Windows, BSD) it transparently uses the
   **std** engine — Go's `net/http` server — so the same code builds and runs
   unchanged. You opt into a native engine via [`Config.Engine`](/docs/configuration);
@@ -61,7 +62,7 @@ fight.
 |--------|---------------|
 | **Zero-allocation hot path** | `Context` objects are pooled and recycled between requests; H1/H2 fast paths reuse inline buffers and pre-encoded HPACK responses, so typical request/response cycles allocate nothing. |
 | **Protocol × engine model** | Protocol (HTTP/1.1, h2c, Auto) and I/O engine (io_uring, epoll, adaptive, std) are chosen independently via two `Config` fields. Most code never touches either — the defaults are correct. |
-| **Adaptive engine** | The default Linux engine starts on epoll (best for ramp-from-zero and low concurrency) and promotes connections to io_uring under sustained high load, driven by live telemetry. A `WorkloadHint` lets you bias the start choice. |
+| **Adaptive engine** | The default Linux engine starts on epoll (best for ramp-from-zero and low concurrency) and switches to io_uring under sustained high load, driven by live telemetry. Established keep-alive connections **transplant** between the engines in both directions (v1.5.6), so a switch captures the throughput rather than stranding live connections. A `WorkloadHint` lets you bias the start choice. |
 | **Async handler dispatch** | Handlers run inline on the I/O worker by default (lowest latency). Routes that block on I/O opt into a per-connection goroutine with `.Async()`, so the worker stays free to drive other connections. |
 | **Batteries-included middleware** | An in-tree catalog of 30+ middleware packages — auth (JWT, basic, key), CORS, CSRF, compression, caching, rate limiting, sessions, WebSocket, SSE, OpenTelemetry, Prometheus, and more. See [Middleware](/docs/middleware). |
 

--- a/src/content/docs/performance.md
+++ b/src/content/docs/performance.md
@@ -213,15 +213,16 @@ connections to io_uring under sustained high load (`celeris/config.go:43-60`).
 
 | `Config.Engine` | Use it when… |
 | --- | --- |
-| `Adaptive` (default) | You don't want to think about it. Starts epoll, promotes to io_uring under load. |
+| `Adaptive` (default) | You don't want to think about it. Starts epoll, switches to io_uring under load (connections transplant both ways). |
 | `Epoll` | You've measured that your workload is steadily low/medium concurrency and want to pin the behavior. |
 | `IOUring` | You've measured a sustained high-concurrency keep-alive workload and want io_uring from the first connection (Linux 5.10+; needs `RLIMIT_MEMLOCK`). |
 | `Std` | Non-Linux, or you want the plain net/http server for maximum portability. |
 
-Because connections **cannot migrate** between epoll and io_uring once accepted, the
-*starting* engine decides keep-alive throughput — and concurrency is unknowable at
-bind time. The `Config.WorkloadHint` is the one lever that biases Adaptive's start
-choice without hard-pinning the engine (`celeris/config.go:43-78`):
+As of v1.5.6 Adaptive **transplants** established keep-alive connections between
+epoll and io_uring on a switch (both directions), so the *starting* engine no
+longer fixes keep-alive throughput. Concurrency is still unknowable at bind time,
+though, so `Config.WorkloadHint` is the lever that biases Adaptive's start choice
+without hard-pinning the engine (`celeris/config.go:43-78`):
 
 ```go
 s := celeris.New(celeris.Config{


### PR DESCRIPTION
**Version references:** already at v1.5.6 (from the data refresh) — verified no stale `1.5.5` strings remain in docs, and the Go toolchain note still matches celeris's go.mod.

**The real work — behavioral freshness.** v1.5.6's headline feature (#383/#396) is **bidirectional connection transplant**: the adaptive engine now migrates established HTTP/1 keep-alive connections between epoll and io_uring at clean request boundaries, in both directions — fixing the old 'hollow promotion' where keep-alives were stranded on the standby. That's also the **adaptive +15% jump** the new Versions chart shows.

The docs repeated the now-false premise — *'connections cannot migrate once accepted'* and *'promotes new connections only'* — across **four pages**. Rewrote them accurately and consistently:
- **engines.md** — Adaptive section, the (now bidirectional) controller behavior, and the WorkloadHint framing.
- **performance.md** / **configuration.md** — the 'start engine fixes keep-alive throughput' claims.
- **introduction.md** — engine bullets now note the bidirectional transplant.

Grounded in the **v1.5.6 release notes + `adaptive/{transplant,controller}.go` at the v1.5.6 tag** (my local checkout was a WIP branch with stale leftover comments — I checked the tag to document released behavior). Also audited the other recent fixes (keyauth `ErrUnauthorized` chaining, overload godoc, pg prepared-statement cache) — docs already consistent, no change needed.

Verified: `bun run build`/`check` 0 errors, anchor link resolves, transplant text renders.